### PR TITLE
Fix property descriptions with line break and default value empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "node-dir": "^0.1.16",
     "react": "^15.4.2",
     "react-docgen": "^2.13.0",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/__mocks__/ExampleComponent.js
+++ b/src/__mocks__/ExampleComponent.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var PropTypes = require('prop-types');
 
 /**
  * General component description.
@@ -15,23 +16,30 @@ var React = require('react');
 var Component = React.createClass({
   propTypes: {
     /**
+     * Description of prop "toe" has one break line
+     * here following more comments and has default
+     * empty string.
+     */
+    toe: PropTypes.string,
+    /**
      * Description of prop "foo".
      */
-    foo: React.PropTypes.number,
+    foo: PropTypes.number,
     /**
      * Description of prop "bar" (a custom validation function).
      */
     bar: function(props, propName, componentName) {
       // ...
     },
-    baz: React.PropTypes.oneOfType([
-      React.PropTypes.number,
-      React.PropTypes.string
+    baz: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
     ]),
   },
 
   getDefaultProps: function() {
     return {
+      toe: '',
       foo: 42,
       bar: 21
     };

--- a/src/__mocks__/ExampleComponent.js
+++ b/src/__mocks__/ExampleComponent.js
@@ -22,6 +22,10 @@ var Component = React.createClass({
      */
     toe: PropTypes.string,
     /**
+     * Description of prop "finger".
+     */
+    finger: PropTypes.string,
+    /**
      * Description of prop "foo".
      */
     foo: PropTypes.number,
@@ -39,6 +43,7 @@ var Component = React.createClass({
 
   getDefaultProps: function() {
     return {
+      finger: 'medium',
       toe: '',
       foo: 42,
       bar: 21

--- a/src/__tests__/react-doc-generator.test.js
+++ b/src/__tests__/react-doc-generator.test.js
@@ -112,6 +112,8 @@ describe('react-doc-generator', () => {
                         expect(result).toContain('Property | Type | Required | Default value | Description');
                         expect(result).toContain(':--- | :--- | :--- | :--- | :---');
                         expect(result).toContain('Description of prop &quot;toe&quot; has one break line here following more comments and has default empty string.');
+                        expect(result).toContain('toe|string|no|&#x27;&#x27;|');
+                        expect(result).toContain('finger|string|no|&#x27;medium&#x27;|');
                         expect((/^\*\*([a-zA-Z/_.]+)\*\*$/igm).test(result)).toBeTruthy();
                         expect((/^### (.*)$/igm).test(result)).toBeTruthy();
                         expect(lines[lines.length - 2]).toContain(pkg.version);

--- a/src/__tests__/react-doc-generator.test.js
+++ b/src/__tests__/react-doc-generator.test.js
@@ -111,6 +111,7 @@ describe('react-doc-generator', () => {
                         expect(lines[0]).toContain('MyTitleXYZ');
                         expect(result).toContain('Property | Type | Required | Default value | Description');
                         expect(result).toContain(':--- | :--- | :--- | :--- | :---');
+                        expect(result).toContain('Description of prop &quot;toe&quot; has one break line here following more comments and has default empty string.');
                         expect((/^\*\*([a-zA-Z/_.]+)\*\*$/igm).test(result)).toBeTruthy();
                         expect((/^### (.*)$/igm).test(result)).toBeTruthy();
                         expect(lines[lines.length - 2]).toContain(pkg.version);

--- a/src/react-doc-generator.js
+++ b/src/react-doc-generator.js
@@ -80,6 +80,14 @@ if (Command.args.length !== 1) {
                                     obj.defaultValue.value = '<See the source code>';
                                 }
                             }
+                            if (obj.description) {
+                              const processedDescription = obj.description
+                              .split('\n')
+                              .map(text => text.replace(/(^\s+|\s+$)/, ''))
+                              .map(hasValidValue => hasValidValue)
+                              .join(' ');
+                              obj.description = processedDescription;
+                            }
                         });
                     }
 

--- a/src/react-doc-generator.js
+++ b/src/react-doc-generator.js
@@ -76,7 +76,10 @@ if (Command.args.length !== 1) {
                         Object.keys(component.props).forEach(key => {
                             let obj = component.props[key];
                             if (obj.defaultValue) {
-                                if ((/[^\w\s.&:\-+*,!@%$]+/igm).test(obj.defaultValue.value)) {
+                                const isString = obj.type.name === 'string'
+                                    && typeof obj.defaultValue.value === 'string';
+                                const isInvalidValue = (/[^\w\s.&:\-+*,!@%$]+/igm).test(obj.defaultValue.value);
+                                if (isInvalidValue && !isString) {
                                     obj.defaultValue.value = '<See the source code>';
                                 }
                             }


### PR DESCRIPTION
I would like to contribute to this project adding fixes to empty string detection and problems when we have property description with line breaks. 
Also, I have added a dependency to 'prop-types' which is recommended by the Facebook team.

Thanks for the great job done with this library. Honestly, it is very helpful.